### PR TITLE
Add employee routes for account management

### DIFF
--- a/src/core/conta/ContaController.ts
+++ b/src/core/conta/ContaController.ts
@@ -16,4 +16,19 @@ export class ContaController {
         const resposta = await this.contaService.criarConta(criarContaDTO)
         return resposta;
     }
+
+    public async atualizarConta(contaDto: CriarContaDTO & { id_conta: string }){
+        const resposta = await this.contaService.atualizarConta(contaDto);
+        return resposta;
+    }
+
+    public async deletarConta(id_conta: string){
+        const resposta = await this.contaService.deletarConta(id_conta);
+        return resposta;
+    }
+
+    public async buscarContaPorId(id_conta: string){
+        const resposta = await this.contaService.buscarContaPorId(id_conta);
+        return resposta;
+    }
 }

--- a/src/core/conta/ContaRepositorio.ts
+++ b/src/core/conta/ContaRepositorio.ts
@@ -110,7 +110,7 @@ export class ContaRepositorio {
     // Vamos fazer valer a regra que só pode 1 ccnta por tipo de conta para cada cliente
     public async tipoDeContaJaExiste(id_cliente: string, tipo_conta: TipoConta) {
         const sql = `
-            SELECT 
+            SELECT
                 COUNT(id_conta) as existe
             FROM conta
             WHERE id_cliente = ? AND tipo_conta = ?
@@ -122,5 +122,59 @@ export class ContaRepositorio {
             throw new Error(`Erro ao quantidade de tipos de conta`)
         }
 
+    }
+
+    public async atualizarConta(conta: Conta): Promise<any> {
+        const sql = `
+            UPDATE conta SET
+                id_agencia = ?,
+                id_cliente = ?,
+                saldo = ?,
+                data_abertura = ?,
+                status = ?,
+                tipo_conta = ?
+            WHERE id_conta = ?
+        `;
+
+        try {
+            const [resposta]: any = await this.pool.query<ResultSetHeader>(sql, [
+                conta.getIdAgencia(),
+                conta.getIdCliente(),
+                conta.getSaldo(),
+                conta.getDataAbertura(),
+                conta.getStatus(),
+                conta.getTipoConta(),
+                conta.getIdConta()
+            ]);
+            return { afetados: resposta.affectedRows };
+        } catch (erro: any) {
+            const erroTratado = tratarCodigosDeErroSql(erro);
+            if (erroTratado !== false) {
+                return erroTratado;
+            }
+            return {
+                erro: true,
+                mensagem: 'Erro ao atualizar conta',
+                codigo: 500
+            }
+        }
+    }
+
+    public async deletarConta(id_conta: string): Promise<any> {
+        const sql = `DELETE FROM conta WHERE id_conta = ?`;
+        try {
+            const [resposta]: any = await this.pool.query<ResultSetHeader>(sql, [id_conta]);
+            return { afetados: resposta.affectedRows };
+        } catch (erro: any) {
+            const erroTratado = tratarCodigosDeErroSql(erro);
+            if (erroTratado !== false) {
+                return erroTratado;
+            }
+            return {
+                erro: true,
+                mensagem: 'Erro ao deletar conta',
+                codigo: 500
+            }
+        }
     }
 }

--- a/src/core/conta/ContaService.ts
+++ b/src/core/conta/ContaService.ts
@@ -37,4 +37,54 @@ export class ContaService {
         }
 
     }
+
+    public async atualizarConta(contaDto: CriarContaDTO & { id_conta: string }) {
+        try {
+            const conta = new Conta(
+                contaDto.id_agencia,
+                contaDto.saldo,
+                contaDto.id_cliente,
+                contaDto.data_abertura,
+                contaDto.status,
+                contaDto.tipo_conta
+            );
+
+            // Força o id original
+            (conta as any).id_conta = contaDto.id_conta;
+            const resposta = await this.contaRepositorio.atualizarConta(conta);
+            return resposta;
+        } catch (erro) {
+            return {
+                erro: true,
+                mensagem: 'Erro inesperado ao atualizar conta',
+                codigo: 500
+            }
+        }
+    }
+
+    public async deletarConta(id_conta: string) {
+        try {
+            const resposta = await this.contaRepositorio.deletarConta(id_conta);
+            return resposta;
+        } catch (erro) {
+            return {
+                erro: true,
+                mensagem: 'Erro inesperado ao deletar conta',
+                codigo: 500
+            }
+        }
+    }
+
+    public async buscarContaPorId(id_conta: string) {
+        try {
+            const resposta = await this.contaRepositorio.buscarContaPorId(id_conta);
+            return resposta;
+        } catch (erro) {
+            return {
+                erro: true,
+                mensagem: 'Erro ao buscar conta',
+                codigo: 500
+            }
+        }
+    }
 }

--- a/src/core/conta/conta.routes.ts
+++ b/src/core/conta/conta.routes.ts
@@ -4,6 +4,8 @@ import { autenticarJWT, autenticarJWTComOTP, rotaProtegidaParaCliente, rotaProte
 import { ContaController } from "./ContaController";
 import { validarDto } from "../../middlewares/validar-dto";
 import { CriarContaDTO } from "./dto/CriarContaDto";
+import { AtualizarContaDto } from "./dto/AtualizarContaDto";
+import { IdContaDto } from "./dto/IdContaDto";
 
 
 const router = Router();
@@ -11,10 +13,65 @@ const contaController = new ContaController();
 
 router.post(
   "/",
-  validarDto(CriarContaDTO), 
+  validarDto(CriarContaDTO),
+  rotaProtegidaParaFuncionario,
   async (req, res, next) => {
     try {
       const resposta = await contaController.criarConta(req.body);
+      if(resposta?.erro){
+        res.status(resposta.codigo ? resposta.codigo : 500).json({erro: resposta.erro, mensagem: resposta.mensagem})
+        return;
+      }
+      res.json(resposta);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+router.put(
+  "/",
+  validarDto(AtualizarContaDto),
+  rotaProtegidaParaFuncionario,
+  async (req, res, next) => {
+    try {
+      const resposta = await contaController.atualizarConta(req.body);
+      if(resposta?.erro){
+        res.status(resposta.codigo ? resposta.codigo : 500).json({erro: resposta.erro, mensagem: resposta.mensagem})
+        return;
+      }
+      res.json(resposta);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+router.delete(
+  "/:id_conta",
+  validarParamsDto(IdContaDto),
+  rotaProtegidaParaFuncionario,
+  async (req, res, next) => {
+    try {
+      const resposta = await contaController.deletarConta(req.body.id_conta);
+      if(resposta?.erro){
+        res.status(resposta.codigo ? resposta.codigo : 500).json({erro: resposta.erro, mensagem: resposta.mensagem})
+        return;
+      }
+      res.json(resposta);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+router.get(
+  "/:id_conta",
+  validarParamsDto(IdContaDto),
+  rotaProtegidaParaFuncionario,
+  async (req, res, next) => {
+    try {
+      const resposta = await contaController.buscarContaPorId(req.body.id_conta);
       if(resposta?.erro){
         res.status(resposta.codigo ? resposta.codigo : 500).json({erro: resposta.erro, mensagem: resposta.mensagem})
         return;

--- a/src/core/conta/dto/AtualizarContaDto.ts
+++ b/src/core/conta/dto/AtualizarContaDto.ts
@@ -1,0 +1,25 @@
+import { IsUUID, IsNumber, IsDateString, IsEnum } from 'class-validator';
+import { TipoConta } from '../interfaces/interfaces';
+
+export class AtualizarContaDto {
+  @IsUUID()
+  id_conta!: string;
+
+  @IsUUID()
+  id_agencia!: string;
+
+  @IsNumber()
+  saldo!: number;
+
+  @IsEnum(TipoConta, {message: "Tipo conta deve ser 'CORRENTE', 'POUPANCA' ou 'INVESTIMENTO'"})
+  tipo_conta!: TipoConta;
+
+  @IsUUID()
+  id_cliente!: string;
+
+  @IsDateString()
+  data_abertura!: string;
+
+  @IsNumber()
+  status!: number;
+}

--- a/src/core/conta/dto/IdContaDto.ts
+++ b/src/core/conta/dto/IdContaDto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class IdContaDto {
+  @IsUUID()
+  id_conta!: string;
+}

--- a/src/middlewares/validar-jwt.ts
+++ b/src/middlewares/validar-jwt.ts
@@ -105,13 +105,18 @@ export function rotaProtegidaParaFuncionario(req: Request, res: Response, next: 
       }
 
       if(!payload.eFuncionario){
-        res.status(401).json({ 
+        res.status(401).json({
           erro: true,
           mensagem: 'Permissão negada, rota protegida para funcionários'
-        })
+        });
+        return;
       }
-    } catch (erro) {
 
+      req.user = payload;
+      next();
+    } catch (erro) {
+      res.status(403).json({ mensagem: 'Token inválido ou expirado' });
+      return;
     }
   }
 }
@@ -135,13 +140,18 @@ export function rotaProtegidaParaCliente(req: Request, res: Response, next: Next
       }
 
       if(!payload.eCliente){
-        res.status(401).json({ 
+        res.status(401).json({
           erro: true,
           mensagem: 'Permissão negada, rota protegida para clientes'
-        })
+        });
+        return;
       }
-    } catch (erro) {
 
+      req.user = payload;
+      next();
+    } catch (erro) {
+      res.status(403).json({ mensagem: 'Token inválido ou expirado' });
+      return;
     }
   }
 }


### PR DESCRIPTION
## Summary
- expand JWT middleware to call `next()` when authorized
- allow employees to create, update, delete and fetch accounts
- implement update/delete methods in account repository and service
- expose new controller endpoints and DTOs for account management

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850b2ea1c3c832fa88cf8877bf4ad76